### PR TITLE
Updated README with instructions to resolve errors including Detector.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ or
 setenv LD_LIBRARY_PATH .:$LD_LIBRARY_PATH
 ```
 
-Also, in case you see this error:  'eicsmear/smear/Detector.h' file not found, make sure that you set the include path like so:
+Also, in case you see this error:  'eicsmear/smear/Detector.h' file not found, make sure that you set the include path like so, before compiling:
 
 ```
 export ROOT_INCLUDE_PATH=path-to-eic-smear-install/include

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ or
 setenv LD_LIBRARY_PATH .:$LD_LIBRARY_PATH
 ```
 
+Also, in case you see this error:  'eicsmear/smear/Detector.h' file not found, make sure that you set the include path like so:
+
+```
+export ROOT_INCLUDE_PATH=path-to-eic-smear-install/include
+```
 A variety of tests are generated from the tests directory:
 
 ```

--- a/eicsmeardetectors.hh
+++ b/eicsmeardetectors.hh
@@ -5,7 +5,8 @@
 #include <iostream>
 #include <cctype>
 
-#include "/home/samuel/eic/eic-smear/include/eicsmear/smear/Detector.h"
+#include "eicsmear/smear/Detector.h"
+//#include "/home/samuel/eic/eic-smear/include/eicsmear/smear/Detector.h"
 // #include "eicsmear/smear/NumSigmaPid.h"
 // #include "piddetectors/TofBarrelSmearer.h"
 // #include "piddetectors/tofBarrel.h"

--- a/eicsmeardetectors.hh
+++ b/eicsmeardetectors.hh
@@ -6,7 +6,6 @@
 #include <cctype>
 
 #include "eicsmear/smear/Detector.h"
-//#include "/home/samuel/eic/eic-smear/include/eicsmear/smear/Detector.h"
 // #include "eicsmear/smear/NumSigmaPid.h"
 // #include "piddetectors/TofBarrelSmearer.h"
 // #include "piddetectors/tofBarrel.h"

--- a/eicsmeardetectors.hh
+++ b/eicsmeardetectors.hh
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <cctype>
 
-#include "eicsmear/smear/Detector.h"
+#include "/home/samuel/eic/eic-smear/include/eicsmear/smear/Detector.h"
 // #include "eicsmear/smear/NumSigmaPid.h"
 // #include "piddetectors/TofBarrelSmearer.h"
 // #include "piddetectors/tofBarrel.h"


### PR DESCRIPTION
There was an error raised during compilation which was reported by some groups:
eicsmear/smear/Detector.h' file not found
To resolve this, the ROOT_INCLUDE_PATH must be set eic-smear installation folder before compilation:
export ROOT_INCLUDE_PATH=path-to-eic-smear-install/include
This part has been added in the README file to help others who might be facing this issue.