### PR TITLE
Added PID acceptance in the B0 for pions, kaons, photons, and Pi0 for…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ These are recommended for Yellow Report work. This collection will grow as the d
 These are derived from an official detector, customized or extended for specific working group needs.
 |Name| min. version | Details and Comments |
 | --- | --- | --- |
-|MatrixDetector 0.1 with Far Forward detectors | 1.1.0 | Based on the Detector Matrix from June 16 2020 with additional ZDC, B0, and Roman Pots, as found in the [Detector Forward-IR Wiki](https://wiki.bnl.gov/eicug/index.php/Yellow_Report_Detector_Forward-IR). The ZDC only accepts neutrons and photons by default. The Build function accepts the beam momentum per nucleon as an integer parameter. Only 275, 100, 41 (e+P), and 135 (e+D) are accepted. These are ROUGH approximations only!|
+|MatrixDetector 0.1 with Far Forward detectors | 1.1.0 | Based on the
+Detector Matrix from June 16 2020 with additional ZDC, B0, and Roman
+Pots, as found in the
+[Detector Forward-IR Wiki](https://wiki.bnl.gov/eicug/index.php/Yellow_Report_Detector_Forward-IR). The
+ZDC only accepts neutrons and photons by default. The Build function
+accepts the beam momentum per nucleon as an integer parameter. Only
+275, 100, 41 (e+P), and 135 (e+D) are accepted. B0 accepts  pi, K, gamma, and pi0, These are ROUGH approximations only!|
 |MatrixDetector 0.1 with Barrel TOF | 1.1.1 | Incorporated tofBarrel from https://gitlab.com/preghenella/pid. Based on the Detector Matrix from June 16 2020. This is under active development and not intended to be used widely yet.|
 
 #### Unofficial parameterizations ####

--- a/SmearMatrixDetector_0_1_FF.cxx
+++ b/SmearMatrixDetector_0_1_FF.cxx
@@ -263,16 +263,34 @@ Smear::Detector BuildMatrixDetector_0_1_FF( const int beam_mom_nn  ) {
   Smear::Device B0P(Smear::kP, pformula);
   B0P.Accept.AddZone(B0zone);
   B0P.Accept.AddParticle(2212);
+  B0P.Accept.AddParticle(22);
+  B0P.Accept.AddParticle(211);
+  B0P.Accept.AddParticle(-211);
+  B0P.Accept.AddParticle(111);
+  B0P.Accept.AddParticle(321);
+  B0P.Accept.AddParticle(-321);
   det.AddDevice(B0P);
 
   Smear::Device B0Pt(Smear::kPt, ptformula);
   B0Pt.Accept.AddZone(B0zone);
   B0Pt.Accept.AddParticle(2212);
+  B0Pt.Accept.AddParticle(22);
+  B0Pt.Accept.AddParticle(211);
+  B0Pt.Accept.AddParticle(-211);
+  B0Pt.Accept.AddParticle(111);
+  B0Pt.Accept.AddParticle(321);
+  B0Pt.Accept.AddParticle(-321);
   det.AddDevice(B0Pt);
   
   Smear::Device B0phi(Smear::kPhi, "0");
   B0phi.Accept.AddZone(B0zone);
   B0phi.Accept.AddParticle(2212);
+  B0phi.Accept.AddParticle(22);
+  B0phi.Accept.AddParticle(211);
+  B0phi.Accept.AddParticle(-211);
+  B0phi.Accept.AddParticle(111);
+  B0phi.Accept.AddParticle(321);
+  B0phi.Accept.AddParticle(-321);
   det.AddDevice(B0phi);
 
   // For protons with p_z/(beam momentum / nucleus )>.6 – "Roman pots"


### PR DESCRIPTION
… the D&T group rapidity gap studies.

I just added "AddParticle" calls to the B0 to include pions, kaons, photons, and pi0 for the D&T group.