### PR TITLE
Tracking Preview

### DIFF
--- a/BuildByName.cxx
+++ b/BuildByName.cxx
@@ -24,6 +24,10 @@ Smear::Detector BuildByName (std::string dname){
        dname == "TRACKING_0_2_B1_5T" ||
        dname == "TRACKING02B15" ) return BuildTrackingPreview_0_2_B1_5T();
 
+  if ( dname == "TRACKINGPREVIEW_0_2_B3T"  ||
+       dname == "TRACKING_0_2_B3" ||
+       dname == "TRACKING02B3" ) return BuildTrackingPreview_0_2_B3T();
+
     
 
   // -- Inofficial detector scripts

--- a/BuildByName.cxx
+++ b/BuildByName.cxx
@@ -18,8 +18,13 @@ Smear::Detector BuildByName (std::string dname){
        dname == "PERFECT" ) return BuildPerfectDetector();
 
   // EXPERIMENTAL
-  if ( dname == "TOF" ) return BuildWithTof();
-  if ( dname == "MATRIXTOF" ) return BuildMatrixDetector_0_1_TOF();
+  // if ( dname == "MATRIXTOF" ) return BuildMatrixDetector_0_1_TOF();
+  
+  if ( dname == "TRACKINGPREVIEW_0_2_B1_5T"  ||
+       dname == "TRACKING_0_2_B1_5T" ||
+       dname == "TRACKING02B15" ) return BuildTrackingPreview_0_2_B1_5T();
+
+    
 
   // -- Inofficial detector scripts
   // ---- BeAST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(
    # piddetectors/tofBarrel.C
 
    SmearTrackingPreview_0_2_B1_5T.cxx
+   SmearTrackingPreview_0_2_B3T.cxx
    )
 
 # include directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,10 @@ add_library(
    SmearePHENIX_0_0.cxx
    SmeareSTAR_0_0.cxx
    BuildByName.cxx
-   SmearWithTof.cxx
-   SmearMatrixDetector_0_1_TOF.cxx
-   piddetectors/tofBarrel.C
+   # SmearMatrixDetector_0_1_TOF.cxx
+   # piddetectors/tofBarrel.C
+
+   SmearTrackingPreview_0_2_B1_5T.cxx
    )
 
 # include directories

--- a/README.md
+++ b/README.md
@@ -27,13 +27,8 @@ These are recommended for Yellow Report work. This collection will grow as the d
 These are derived from an official detector, customized or extended for specific working group needs.
 |Name| min. version | Details and Comments |
 | --- | --- | --- |
-|MatrixDetector 0.1 with Far Forward detectors | 1.1.0 | Based on the
-Detector Matrix from June 16 2020 with additional ZDC, B0, and Roman
-Pots, as found in the
-[Detector Forward-IR Wiki](https://wiki.bnl.gov/eicug/index.php/Yellow_Report_Detector_Forward-IR). The
-ZDC only accepts neutrons and photons by default. The Build function
-accepts the beam momentum per nucleon as an integer parameter. Only
-275, 100, 41 (e+P), and 135 (e+D) are accepted. B0 accepts  pi, K, gamma, and pi0, These are ROUGH approximations only!|
+|TrackingPreview 0.2 for B=1.5T and B=3T | 1.1.0 | Based on the Detector Matrix from June 16 2020 with tracking resolution from [Tracking Only Matrix](https://indico.bnl.gov/event/9984/contributions/43066/attachments/31173/49186/YR_Detector_Matrix_Tracking_only_10282020.xlsx) for evaluation by PWGs. Shortcuts for BuildByName are ```TRACKINGPREVIEW_0_2_B1_5T```, ```TRACKING_0_2_B1_5T```, or ```TRACKING02B15``` (and similar for 3T) |
+|MatrixDetector 0.1 with Far Forward detectors | 1.1.0 | Based on the Detector Matrix from June 16 2020 with additional ZDC, B0, and Roman Pots, as found in the [Detector Forward-IR Wiki](https://wiki.bnl.gov/eicug/index.php/Yellow_Report_Detector_Forward-IR). The ZDC only accepts neutrons and photons by default. The Build function accepts the beam momentum per nucleon as an integer parameter. Only 275, 100, 41 (e+P), and 135 (e+D) are accepted. B0 accepts  pi, K, gamma, and pi0, These are ROUGH approximations only!|
 |MatrixDetector 0.1 with Barrel TOF | 1.1.1 | Incorporated tofBarrel from https://gitlab.com/preghenella/pid. Based on the Detector Matrix from June 16 2020. This is under active development and not intended to be used widely yet.|
 
 #### Unofficial parameterizations ####

--- a/SmearTrackingPreview_0_2_B1_5T.cxx
+++ b/SmearTrackingPreview_0_2_B1_5T.cxx
@@ -1,0 +1,214 @@
+// Based on
+// https://physdiv.jlab.org/DetectorMatrix/
+// Using everything from v 0.1 from June 16 2020 except:
+// - EMCal coverage reduced to |eta|<3.5
+// - Tracking parameters from B=1.5T Matrix preview at
+//   https://indico.bnl.gov/event/9984/contributions/43066/attachments/31173/49186/YR_Detector_Matrix_Tracking_only_10282020.xlsx
+
+// Reminder:
+// Acceptance::Zone(double theta = 0., double = TMath::Pi(),
+//      double phi = 0., double = TMath::TwoPi(),
+//      double E = 0., double = TMath::Infinity(),
+//      double p = 0., double = TMath::Infinity(),
+//      double pt = 0., double = TMath::Infinity(),
+//      double pz = -TMath::Infinity(), double = TMath::Infinity());
+
+
+#include "eicsmear/erhic/VirtualParticle.h"
+#include "eicsmear/smear/Acceptance.h"
+#include "eicsmear/smear/Device.h"
+#include "eicsmear/smear/Detector.h"
+#include "eicsmear/smear/Smearer.h"
+#include "eicsmear/smear/ParticleMCS.h"
+#include "eicsmear/smear/PerfectID.h"
+#include <eicsmear/smear/Smear.h>
+#include <eicsmear/erhic/ParticleMC.h>
+#include "Math/Vector4D.h"
+
+// declare static --> local to this file, won't clash with others
+static double ThetaFromEta( const double eta );
+
+Smear::Detector BuildTrackingPreview_0_2_B1_5T() {
+  gSystem->Load("libeicsmear");
+
+  // Create the detector object to hold all devices
+  Smear::Detector det;
+
+  // The framework provides implementations of three kinematic calculation methods
+  // from smeared values
+  // NM - "Null method" uses the scattered lepton.
+  // DA - Double Angle method
+  // JB - Jacquet-Blondel method
+  // Important Notes:
+  // - All methods rely on measured energy and momentum components (lepton for NM, hadrons for DA, JB).
+  //   In order to rely on these methods, you therefore _need_ to cover the relevant
+  //   regions with smearers for momentum, angles and energy.
+  // - This is exacerbated by the fact that in the current implementation a smearing of e.g. P
+  //   may fool the framework into assuming theta is measured to be the initialization value 0,
+  //   leading to nan or inf or otherwise wrong calculations.
+  //   NM catches P=0 and replaces it in calculations with E,
+  //   but JB and DA either don't work at all or report nonsenical values.
+  // - It may be advantageous to use a P measurement in place of E in a more general case.
+  //   In the future, we plan to change to a weighted mean approach.
+  // The summary of the above is that the user should be mindful of the limitations and assumptions in
+  // the calculation of smeared kinematics. Sophisticated calculations are best redone in user code
+  // from the smeared particles directly.
+  det.SetEventKinematicsCalculator("NM DA JB");
+
+  // Perfect phi and theta for all particles
+  // ---------------------------------------
+  // TODO: Better options?
+  // total coverage of the handbook for tracker, ecal, and hcal is -3.5 < eta < 3.5
+  Smear::Acceptance::Zone AngleZoneCommon(ThetaFromEta ( 3.5 ),ThetaFromEta ( -3.5 ));
+  Smear::Device SmearThetaCommon(Smear::kTheta, "0.0");
+  SmearThetaCommon.Accept.AddZone(AngleZoneCommon);
+  SmearThetaCommon.Accept.SetGenre(Smear::kAll);
+  det.AddDevice(SmearThetaCommon);
+
+  Smear::Device SmearPhiCommon(Smear::kPhi, "0.0");
+  SmearPhiCommon.Accept.AddZone(AngleZoneCommon);
+  SmearPhiCommon.Accept.SetGenre(Smear::kAll);
+  det.AddDevice(SmearPhiCommon);
+
+  // Tracking  (B = 1.5 T)
+  // --------
+  // Note: Smear::kCharged checks pdg charge, so includes muons (good)
+  // eta = -3.5 --  -2.5
+  // sigma_p/p ~ 0.2% p + 5%
+  Smear::Acceptance::Zone TrackBack1Zone(ThetaFromEta ( -2.5 ),ThetaFromEta ( -3.5 ));
+  Smear::Device TrackBack1P(Smear::kP, "sqrt( pow ( 0.002*P*P, 2) + pow ( 0.05*P, 2) )");
+  TrackBack1P.Accept.AddZone(TrackBack1Zone);
+  TrackBack1P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackBack1P);
+
+  // eta = -2.5 --  -1
+  // sigma_p/p ~ 0.04% p + 2%
+  Smear::Acceptance::Zone TrackBack2Zone(ThetaFromEta ( -1 ),ThetaFromEta ( -2.5 ));
+  Smear::Device TrackBack2P(Smear::kP, "sqrt( pow ( 0.0004*P*P, 2) + pow ( 0.02*P, 2) )");
+  TrackBack2P.Accept.AddZone(TrackBack2Zone);
+  TrackBack2P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackBack2P);
+
+  // TODO: What to make of this?
+  // "100 MeV/c with 50% acceptance (similar for pi and K)"
+  // Add efficiency?
+  // eta = -1 -- +1
+  // sigma_p/p ~ 0.04% p + 1%
+  Smear::Acceptance::Zone TrackBarrelZone(ThetaFromEta ( 1 ),ThetaFromEta ( -1 ));
+  Smear::Device TrackBarrelP(Smear::kP, "sqrt( pow ( 0.0004*P*P, 2) + pow ( 0.01*P, 2) )");
+  TrackBarrelP.Accept.AddZone(TrackBarrelZone);
+  TrackBarrelP.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackBarrelP);
+
+  // eta = 1 -- 2.5
+  // sigma_p/p ~ 0.04% p+2%
+  Smear::Acceptance::Zone TrackFwd2Zone(ThetaFromEta ( 2.5 ),ThetaFromEta ( 1 ));
+  Smear::Device TrackFwd2P(Smear::kP, "sqrt( pow ( 0.0004*P*P, 2) + pow ( 0.02*P, 2) )");
+  TrackFwd2P.Accept.AddZone(TrackFwd2Zone);
+  TrackFwd2P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackFwd2P);
+
+  // eta = 2.5 -- 3.5
+  // sigma_p/p ~ 0.2% p+5%
+  Smear::Acceptance::Zone TrackFwd1Zone(ThetaFromEta ( 3.5 ),ThetaFromEta ( 2.5 ));
+  Smear::Device TrackFwd1P(Smear::kP, "sqrt( pow ( 0.002*P*P, 2) + pow ( 0.05*P, 2) )");
+  TrackFwd1P.Accept.AddZone(TrackFwd1Zone);
+  TrackFwd1P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackFwd1P);
+
+  // EM Calorimeters
+  // ---------------
+  // Note: Smear::kElectromagnetic == gamma + e. Does not include muons (good)
+
+  // Calorimeter resolution usually given as sigma_E/E = const% + stocastic%/Sqrt{E}
+  // EIC Smear needs absolute sigma: sigma_E = Sqrt{const*const*E*E + stoc*stoc*E}
+
+  // Back
+  // eta = -3.5 -- -2
+  // stoch. = 2%
+  Smear::Acceptance::Zone EmcalBackZone(ThetaFromEta ( -2 ),ThetaFromEta ( -3.5 ));
+  Smear::Device EmcalBack(Smear::kE, "sqrt( pow ( 0.0*E,2 ) + pow( 0.02,2)*E)");
+  EmcalBack.Accept.AddZone(EmcalBackZone);
+  EmcalBack.Accept.SetGenre(Smear::kElectromagnetic);
+  det.AddDevice(EmcalBack);
+
+  // MidBack
+  // eta = -2 -- -1
+  // stoch. = 7%
+  Smear::Acceptance::Zone EmcalMidBackZone(ThetaFromEta ( -1 ),ThetaFromEta ( -2 ));
+  Smear::Device EmcalMidBack(Smear::kE, "sqrt( pow ( 0.0*E,2 ) + pow( 0.07,2)*E)");
+  EmcalMidBack.Accept.AddZone(EmcalMidBackZone);
+  EmcalMidBack.Accept.SetGenre(Smear::kElectromagnetic);
+  det.AddDevice(EmcalMidBack);
+
+  // Forward
+  // eta = -1 -- 3.5
+  // stoch. = 10-12%, use 12%
+  Smear::Acceptance::Zone EmcalFwdZone(ThetaFromEta ( 3.5 ),ThetaFromEta ( -1 ));
+  Smear::Device EmcalFwd(Smear::kE, "sqrt( pow ( 0.0*E,2 ) + pow( 0.12,2)*E)");
+  EmcalFwd.Accept.AddZone(EmcalFwdZone);
+  EmcalFwd.Accept.SetGenre(Smear::kElectromagnetic);
+  det.AddDevice(EmcalFwd);
+
+  // Could turn on perfect PID
+  // Make sure to not cover more than is covered by the other detectors.
+  // Using the smallest region here, but we could add a second one for
+  // the extended EmCal range
+  // Smear::Acceptance::Zone acceptpid(ThetaFromEta(3.5),ThetaFromEta(-3.5));
+  // Smear::PerfectID pid;
+  // pid.Accept.AddZone(acceptpid);
+  // det.AddDevice( pid );
+
+  // Hadronic  Calorimeters
+  // ----------------------
+  // Note: kHadronic == |pdg|>110.
+
+  // Back
+  // eta = -3.5 -- -1
+  // stoch. = 50%
+  Smear::Acceptance::Zone HcalBackZone(ThetaFromEta ( -1 ),ThetaFromEta ( -3.5 ));
+  Smear::Device HcalBack(Smear::kE, "sqrt(pow( 0.0*E, 2) + pow ( 0.5,2) *E)");
+  HcalBack.Accept.AddZone(HcalBackZone);
+  HcalBack.Accept.SetGenre(Smear::kHadronic);
+  det.AddDevice(HcalBack);
+
+  // Barrel
+  // eta = -1 -- 1
+  // The matrix has nothing. As examples, one could turn to
+  // ~CMS
+  // Smear::Device HcalBarrel(Smear::kE, "sqrt( pow( 0.07*E, 2) + pow( 0.85, 2)*E)");
+  // ~Zeus
+  // Smear::Device HcalBarrel(Smear::kE, "sqrt( pow( 0.02*E, 2) + pow( 0.35,2) *E)");
+
+  // Smear::Acceptance::Zone HcalBarrelZone(ThetaFromEta ( 1 ),ThetaFromEta ( -1 ));
+  // HcalBarrel.Accept.AddZone(HcalBarrelZone);
+  // HcalBarrel.Accept.SetGenre(Smear::kHadronic);
+  // det.AddDevice(HcalBarrel);
+
+  // Forward
+  // eta = 1 -- 3.5
+  // stoch. = 50%
+  Smear::Acceptance::Zone HcalFwdZone(ThetaFromEta ( 3.5 ),ThetaFromEta ( 1 ));
+  Smear::Device HcalFwd(Smear::kE, "sqrt(pow( 0.0*E, 2) + pow ( 0.5,2) *E)");
+  HcalFwd.Accept.AddZone(HcalFwdZone);
+  HcalFwd.Accept.SetGenre(Smear::kHadronic);
+  det.AddDevice(HcalFwd);
+
+  // Not covered:
+  // Tracker material budget X/X0 <~5%
+  // Low-Q^2 tagger: -6.9<eta<-5.8: Delta_theta/theta < 1.5%; 10^-6 < Q2 < 10^-2 GeV2
+  // Proton spectrometer:  eta>6.2: sigma_intrinsic(|t|)/|t| < 1%; Acceptance: 0.2 < pT < 1.2 GeV/c
+  // Barrel vertexing: sigma_xyz ~ 20 microns, d0(z) ~ d0(r phi) ~ (20 microns)/(pT [GeV])  + 5 microns
+  // Central muon detection
+
+  return det;
+}
+
+// -------------------------------------------------------------------
+double ThetaFromEta( const double eta ) {
+  if ( !std::isnan(eta) && !std::isinf(eta)   ) {
+    return 2.0 * atan( exp( -eta ));
+  }
+  throw std::runtime_error("ThetaFromEta called with NaN or Inf");
+  return -1;
+}

--- a/SmearTrackingPreview_0_2_B3T.cxx
+++ b/SmearTrackingPreview_0_2_B3T.cxx
@@ -1,0 +1,214 @@
+// Based on
+// https://physdiv.jlab.org/DetectorMatrix/
+// Using everything from v 0.1 from June 16 2020 except:
+// - EMCal coverage reduced to |eta|<3.5
+// - Tracking parameters from B=3T Matrix preview at
+//   https://indico.bnl.gov/event/9984/contributions/43066/attachments/31173/49186/YR_Detector_Matrix_Tracking_only_10282020.xlsx
+
+// Reminder:
+// Acceptance::Zone(double theta = 0., double = TMath::Pi(),
+//      double phi = 0., double = TMath::TwoPi(),
+//      double E = 0., double = TMath::Infinity(),
+//      double p = 0., double = TMath::Infinity(),
+//      double pt = 0., double = TMath::Infinity(),
+//      double pz = -TMath::Infinity(), double = TMath::Infinity());
+
+
+#include "eicsmear/erhic/VirtualParticle.h"
+#include "eicsmear/smear/Acceptance.h"
+#include "eicsmear/smear/Device.h"
+#include "eicsmear/smear/Detector.h"
+#include "eicsmear/smear/Smearer.h"
+#include "eicsmear/smear/ParticleMCS.h"
+#include "eicsmear/smear/PerfectID.h"
+#include <eicsmear/smear/Smear.h>
+#include <eicsmear/erhic/ParticleMC.h>
+#include "Math/Vector4D.h"
+
+// declare static --> local to this file, won't clash with others
+static double ThetaFromEta( const double eta );
+
+Smear::Detector BuildTrackingPreview_0_2_B3T() {
+  gSystem->Load("libeicsmear");
+
+  // Create the detector object to hold all devices
+  Smear::Detector det;
+
+  // The framework provides implementations of three kinematic calculation methods
+  // from smeared values
+  // NM - "Null method" uses the scattered lepton.
+  // DA - Double Angle method
+  // JB - Jacquet-Blondel method
+  // Important Notes:
+  // - All methods rely on measured energy and momentum components (lepton for NM, hadrons for DA, JB).
+  //   In order to rely on these methods, you therefore _need_ to cover the relevant
+  //   regions with smearers for momentum, angles and energy.
+  // - This is exacerbated by the fact that in the current implementation a smearing of e.g. P
+  //   may fool the framework into assuming theta is measured to be the initialization value 0,
+  //   leading to nan or inf or otherwise wrong calculations.
+  //   NM catches P=0 and replaces it in calculations with E,
+  //   but JB and DA either don't work at all or report nonsenical values.
+  // - It may be advantageous to use a P measurement in place of E in a more general case.
+  //   In the future, we plan to change to a weighted mean approach.
+  // The summary of the above is that the user should be mindful of the limitations and assumptions in
+  // the calculation of smeared kinematics. Sophisticated calculations are best redone in user code
+  // from the smeared particles directly.
+  det.SetEventKinematicsCalculator("NM DA JB");
+
+  // Perfect phi and theta for all particles
+  // ---------------------------------------
+  // TODO: Better options?
+  // total coverage of the handbook for tracker, ecal, and hcal is -3.5 < eta < 3.5
+  Smear::Acceptance::Zone AngleZoneCommon(ThetaFromEta ( 3.5 ),ThetaFromEta ( -3.5 ));
+  Smear::Device SmearThetaCommon(Smear::kTheta, "0.0");
+  SmearThetaCommon.Accept.AddZone(AngleZoneCommon);
+  SmearThetaCommon.Accept.SetGenre(Smear::kAll);
+  det.AddDevice(SmearThetaCommon);
+
+  Smear::Device SmearPhiCommon(Smear::kPhi, "0.0");
+  SmearPhiCommon.Accept.AddZone(AngleZoneCommon);
+  SmearPhiCommon.Accept.SetGenre(Smear::kAll);
+  det.AddDevice(SmearPhiCommon);
+
+  // Tracking  (B = 3 T)
+  // --------
+  // Note: Smear::kCharged checks pdg charge, so includes muons (good)
+  // eta = -3.5 --  -2.5
+  // sigma_p/p ~ 0.1% p + 2%
+  Smear::Acceptance::Zone TrackBack1Zone(ThetaFromEta ( -2.5 ),ThetaFromEta ( -3.5 ));
+  Smear::Device TrackBack1P(Smear::kP, "sqrt( pow ( 0.001*P*P, 2) + pow ( 0.02*P, 2) )");
+  TrackBack1P.Accept.AddZone(TrackBack1Zone);
+  TrackBack1P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackBack1P);
+
+  // eta = -2.5 --  -1
+  // sigma_p/p ~ 0.02% p + 1%
+  Smear::Acceptance::Zone TrackBack2Zone(ThetaFromEta ( -1 ),ThetaFromEta ( -2.5 ));
+  Smear::Device TrackBack2P(Smear::kP, "sqrt( pow ( 0.0002*P*P, 2) + pow ( 0.01*P, 2) )");
+  TrackBack2P.Accept.AddZone(TrackBack2Zone);
+  TrackBack2P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackBack2P);
+
+  // TODO: What to make of this?
+  // "200 MeV/c with 50% acceptance (similar for pi and K)"
+  // Add efficiency?
+  // eta = -1 -- +1
+  // sigma_p/p ~ 0.02% p + 0.05%
+  Smear::Acceptance::Zone TrackBarrelZone(ThetaFromEta ( 1 ),ThetaFromEta ( -1 ));
+  Smear::Device TrackBarrelP(Smear::kP, "sqrt( pow ( 0.0002*P*P, 2) + pow ( 0.005*P, 2) )");
+  TrackBarrelP.Accept.AddZone(TrackBarrelZone);
+  TrackBarrelP.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackBarrelP);
+
+  // eta = 1 -- 2.5
+  // sigma_p/p ~ 0.02% p+1%
+  Smear::Acceptance::Zone TrackFwd2Zone(ThetaFromEta ( 2.5 ),ThetaFromEta ( 1 ));
+  Smear::Device TrackFwd2P(Smear::kP, "sqrt( pow ( 0.0002*P*P, 2) + pow ( 0.01*P, 2) )");
+  TrackFwd2P.Accept.AddZone(TrackFwd2Zone);
+  TrackFwd2P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackFwd2P);
+
+  // eta = 2.5 -- 3.5
+  // sigma_p/p ~ 0.1% p+2%
+  Smear::Acceptance::Zone TrackFwd1Zone(ThetaFromEta ( 3.5 ),ThetaFromEta ( 2.5 ));
+  Smear::Device TrackFwd1P(Smear::kP, "sqrt( pow ( 0.001*P*P, 2) + pow ( 0.02*P, 2) )");
+  TrackFwd1P.Accept.AddZone(TrackFwd1Zone);
+  TrackFwd1P.Accept.SetCharge(Smear::kCharged);
+  det.AddDevice(TrackFwd1P);
+
+  // EM Calorimeters
+  // ---------------
+  // Note: Smear::kElectromagnetic == gamma + e. Does not include muons (good)
+
+  // Calorimeter resolution usually given as sigma_E/E = const% + stocastic%/Sqrt{E}
+  // EIC Smear needs absolute sigma: sigma_E = Sqrt{const*const*E*E + stoc*stoc*E}
+
+  // Back
+  // eta = -3.5 -- -2
+  // stoch. = 2%
+  Smear::Acceptance::Zone EmcalBackZone(ThetaFromEta ( -2 ),ThetaFromEta ( -3.5 ));
+  Smear::Device EmcalBack(Smear::kE, "sqrt( pow ( 0.0*E,2 ) + pow( 0.02,2)*E)");
+  EmcalBack.Accept.AddZone(EmcalBackZone);
+  EmcalBack.Accept.SetGenre(Smear::kElectromagnetic);
+  det.AddDevice(EmcalBack);
+
+  // MidBack
+  // eta = -2 -- -1
+  // stoch. = 7%
+  Smear::Acceptance::Zone EmcalMidBackZone(ThetaFromEta ( -1 ),ThetaFromEta ( -2 ));
+  Smear::Device EmcalMidBack(Smear::kE, "sqrt( pow ( 0.0*E,2 ) + pow( 0.07,2)*E)");
+  EmcalMidBack.Accept.AddZone(EmcalMidBackZone);
+  EmcalMidBack.Accept.SetGenre(Smear::kElectromagnetic);
+  det.AddDevice(EmcalMidBack);
+
+  // Forward
+  // eta = -1 -- 3.5
+  // stoch. = 10-12%, use 12%
+  Smear::Acceptance::Zone EmcalFwdZone(ThetaFromEta ( 3.5 ),ThetaFromEta ( -1 ));
+  Smear::Device EmcalFwd(Smear::kE, "sqrt( pow ( 0.0*E,2 ) + pow( 0.12,2)*E)");
+  EmcalFwd.Accept.AddZone(EmcalFwdZone);
+  EmcalFwd.Accept.SetGenre(Smear::kElectromagnetic);
+  det.AddDevice(EmcalFwd);
+
+  // Could turn on perfect PID
+  // Make sure to not cover more than is covered by the other detectors.
+  // Using the smallest region here, but we could add a second one for
+  // the extended EmCal range
+  // Smear::Acceptance::Zone acceptpid(ThetaFromEta(3.5),ThetaFromEta(-3.5));
+  // Smear::PerfectID pid;
+  // pid.Accept.AddZone(acceptpid);
+  // det.AddDevice( pid );
+
+  // Hadronic  Calorimeters
+  // ----------------------
+  // Note: kHadronic == |pdg|>110.
+
+  // Back
+  // eta = -3.5 -- -1
+  // stoch. = 50%
+  Smear::Acceptance::Zone HcalBackZone(ThetaFromEta ( -1 ),ThetaFromEta ( -3.5 ));
+  Smear::Device HcalBack(Smear::kE, "sqrt(pow( 0.0*E, 2) + pow ( 0.5,2) *E)");
+  HcalBack.Accept.AddZone(HcalBackZone);
+  HcalBack.Accept.SetGenre(Smear::kHadronic);
+  det.AddDevice(HcalBack);
+
+  // Barrel
+  // eta = -1 -- 1
+  // The matrix has nothing. As examples, one could turn to
+  // ~CMS
+  // Smear::Device HcalBarrel(Smear::kE, "sqrt( pow( 0.07*E, 2) + pow( 0.85, 2)*E)");
+  // ~Zeus
+  // Smear::Device HcalBarrel(Smear::kE, "sqrt( pow( 0.02*E, 2) + pow( 0.35,2) *E)");
+
+  // Smear::Acceptance::Zone HcalBarrelZone(ThetaFromEta ( 1 ),ThetaFromEta ( -1 ));
+  // HcalBarrel.Accept.AddZone(HcalBarrelZone);
+  // HcalBarrel.Accept.SetGenre(Smear::kHadronic);
+  // det.AddDevice(HcalBarrel);
+
+  // Forward
+  // eta = 1 -- 3.5
+  // stoch. = 50%
+  Smear::Acceptance::Zone HcalFwdZone(ThetaFromEta ( 3.5 ),ThetaFromEta ( 1 ));
+  Smear::Device HcalFwd(Smear::kE, "sqrt(pow( 0.0*E, 2) + pow ( 0.5,2) *E)");
+  HcalFwd.Accept.AddZone(HcalFwdZone);
+  HcalFwd.Accept.SetGenre(Smear::kHadronic);
+  det.AddDevice(HcalFwd);
+
+  // Not covered:
+  // Tracker material budget X/X0 <~5%
+  // Low-Q^2 tagger: -6.9<eta<-5.8: Delta_theta/theta < 1.5%; 10^-6 < Q2 < 10^-2 GeV2
+  // Proton spectrometer:  eta>6.2: sigma_intrinsic(|t|)/|t| < 1%; Acceptance: 0.2 < pT < 1.2 GeV/c
+  // Barrel vertexing: sigma_xyz ~ 20 microns, d0(z) ~ d0(r phi) ~ (20 microns)/(pT [GeV])  + 5 microns
+  // Central muon detection
+
+  return det;
+}
+
+// -------------------------------------------------------------------
+double ThetaFromEta( const double eta ) {
+  if ( !std::isnan(eta) && !std::isinf(eta)   ) {
+    return 2.0 * atan( exp( -eta ));
+  }
+  throw std::runtime_error("ThetaFromEta called with NaN or Inf");
+  return -1;
+}

--- a/eicsmeardetectors.hh
+++ b/eicsmeardetectors.hh
@@ -23,8 +23,8 @@ Smear::Detector BuildeSTAR_0_0();
 Smear::Detector BuildePHENIX_0_0(bool multipleScattering=true);
 
 // experimental
-Smear::Detector BuildWithTof();
-Smear::Detector BuildMatrixDetector_0_1_TOF();
+// Smear::Detector BuildMatrixDetector_0_1_TOF();
+Smear::Detector BuildTrackingPreview_0_2_B1_5T();
 
 
 /** For convenience.

--- a/eicsmeardetectors.hh
+++ b/eicsmeardetectors.hh
@@ -25,6 +25,7 @@ Smear::Detector BuildePHENIX_0_0(bool multipleScattering=true);
 // experimental
 // Smear::Detector BuildMatrixDetector_0_1_TOF();
 Smear::Detector BuildTrackingPreview_0_2_B1_5T();
+Smear::Detector BuildTrackingPreview_0_2_B3T();
 
 
 /** For convenience.

--- a/tests/qaplots.cxx
+++ b/tests/qaplots.cxx
@@ -230,37 +230,28 @@ void FillParticleQA( map<int,pidqacollection>& qabook, const Particle* const inP
     auto& pid = pidcoll.first;
     auto& coll = pidcoll.second;
     if ( pid==0 || inParticle->GetPdgCode() == pid ){
-      
-      // if ( std::abs(inParticleS->GetP()) > epsilon ){
-      //   auto delP = (inParticle->GetP() - inParticleS->GetP()) / inParticle->GetP();
-      //   coll.DelP_th->Fill(inParticle->GetTheta(), delP);
-      // }
-      
-      // if ( std::abs(inParticleS->GetE()) > epsilon ){
-      //   auto delE = (inParticle->GetE() - inParticleS->GetE()) / inParticle->GetE();
-      //   coll.DelE_th->Fill(inParticle->GetTheta(), delE);
-      // }
-      
-      // if ( std::abs(inParticleS->GetTheta()) > epsilon ){
-      //   coll.dTh_p->Fill(inParticle->GetP(), inParticle->GetTheta() - inParticleS->GetTheta());
-      // }
-      
-      // if ( std::abs(inParticleS->GetPhi()) > epsilon ){
-      //   coll.dPhi_p->Fill(inParticle->GetP(), inParticle->GetPhi() - inParticleS->GetPhi());
-      // }
-      
-      auto delP = (inParticle->GetP() - inParticleS->GetP()) / inParticle->GetP();
-      coll.DelP_th->Fill(inParticle->GetTheta(), delP);
-      coll.DelP_eta->Fill(inParticle->GetEta(), delP);
-      
-      auto delE = (inParticle->GetE() - inParticleS->GetE()) / inParticle->GetE();
-      coll.DelE_E->Fill(inParticle->GetE(), delE);
-      coll.DelE_th->Fill(inParticle->GetTheta(), delE);
-      coll.DelE_eta->Fill(inParticle->GetEta(), delE);
-      
-      coll.dTh_p->Fill(inParticle->GetP(), inParticle->GetTheta() - inParticleS->GetTheta());
-      coll.dEta_p->Fill(inParticle->GetP(), inParticle->GetEta() - inParticleS->GetEta());
-      coll.dPhi_p->Fill(inParticle->GetP(), inParticle->GetPhi() - inParticleS->GetPhi());
+
+      if ( inParticleS->IsPSmeared() ){
+	auto delP = (inParticle->GetP() - inParticleS->GetP()) / inParticle->GetP();
+	coll.DelP_th->Fill(inParticle->GetTheta(), delP);
+	coll.DelP_eta->Fill(inParticle->GetEta(), delP);
+      }
+
+      if ( inParticleS->IsESmeared() ){
+	auto delE = (inParticle->GetE() - inParticleS->GetE()) / inParticle->GetE();
+	coll.DelE_E->Fill(inParticle->GetE(), delE);
+	coll.DelE_th->Fill(inParticle->GetTheta(), delE);
+	coll.DelE_eta->Fill(inParticle->GetEta(), delE);
+      }
+	
+      if ( inParticleS->IsThetaSmeared() ){
+	coll.dTh_p->Fill(inParticle->GetP(), inParticle->GetTheta() - inParticleS->GetTheta());
+	coll.dEta_p->Fill(inParticle->GetP(), inParticle->GetEta() - inParticleS->GetEta());
+      }
+
+      if ( inParticleS->IsPhiSmeared() ){
+	coll.dPhi_p->Fill(inParticle->GetP(), inParticle->GetPhi() - inParticleS->GetPhi());
+      }
     }
   }
 }
@@ -364,16 +355,16 @@ void initializepidqabook(const qaparameters& qapars, map<int,pidqacollection>& q
   float pmax = 20;
   int pbins = 80;
 
-  float dpmin = -0.1;
-  float dpmax = 0.1;
+  float dpmin = -0.15;
+  float dpmax = 0.15;
   int dpbins = 100;
   
   float emin = 0;
   float emax = 20;
   int ebins = 80;
 
-  float demin = -1;
-  float demax = 1;
+  float demin = -1.5;
+  float demax = 1.5;
   int debins = 100;
 
   float thmin = 0;
@@ -553,8 +544,7 @@ void PlotQA ( const qaparameters& qapars, eventqacollection& eventqa, map<int,pi
 
   // prep a pdf collection
   new TCanvas;
-  auto pdfname = qapars.outfilebase + qapars.detstring + ".pdf";
-  gPad->SaveAs( pdfname + "[" );
+  gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf[" );
 
   // event-wise qa
 
@@ -563,149 +553,146 @@ void PlotQA ( const qaparameters& qapars, eventqacollection& eventqa, map<int,pi
   if ( eventqa.y_NM ) {
     eventqa.y_NM->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedy_NM, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   if ( eventqa.x_NM ) {
     eventqa.x_NM->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedx_NM, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   if ( eventqa.Q2_NM ) {
     eventqa.Q2_NM->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedQ2_NM, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   // DA
   if ( eventqa.y_DA ) {
     eventqa.y_DA->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedy_DA, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   if ( eventqa.x_DA ) {
     eventqa.x_DA->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedx_DA, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   if ( eventqa.Q2_DA ) {
     eventqa.Q2_DA->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedQ2_DA, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   // JB
   if ( eventqa.y_JB ) {
     eventqa.y_JB->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedy_JB, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   if ( eventqa.x_JB ) {
     eventqa.x_JB->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedx_JB, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
   if ( eventqa.Q2_JB ) {
     eventqa.Q2_JB->Draw("colz");
     t.DrawText( missx,missy, Form("Missed: %ld / %ld",eventqa.missedQ2_JB, qapars.usedevents));
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
 
-  // resolution-style
-  // NM
-  if ( eventqa.dely_NM ) {
-    eventqa.dely_NM->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedy_NM, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  if ( eventqa.delx_NM ) {
-    eventqa.delx_NM->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedx_NM, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  if ( eventqa.delQ2_NM ) {
-    eventqa.delQ2_NM->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedQ2_NM, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  // DA
-  if ( eventqa.dely_DA ) {
-    eventqa.dely_DA->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedy_DA, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  if ( eventqa.delx_DA ) {
-    eventqa.delx_DA->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedx_DA, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  if ( eventqa.delQ2_DA ) {
-    eventqa.delQ2_DA->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedQ2_DA, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  // JB
-  if ( eventqa.dely_JB ) {
-    eventqa.dely_JB->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedy_JB, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  if ( eventqa.delx_JB ) {
-    eventqa.delx_JB->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedx_JB, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
-  if ( eventqa.delQ2_JB ) {
-    eventqa.delQ2_JB->Draw("colz");
-    t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedQ2_JB, qapars.usedevents));
-    gPad->SaveAs( pdfname );
-  }
+  // // resolution-style
+  // // NM
+  // if ( eventqa.dely_NM ) {
+  //   eventqa.dely_NM->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedy_NM, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // if ( eventqa.delx_NM ) {
+  //   eventqa.delx_NM->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedx_NM, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // if ( eventqa.delQ2_NM ) {
+  //   eventqa.delQ2_NM->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedQ2_NM, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // // DA
+  // if ( eventqa.dely_DA ) {
+  //   eventqa.dely_DA->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedy_DA, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // if ( eventqa.delx_DA ) {
+  //   eventqa.delx_DA->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedx_DA, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // if ( eventqa.delQ2_DA ) {
+  //   eventqa.delQ2_DA->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedQ2_DA, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // // JB
+  // if ( eventqa.dely_JB ) {
+  //   eventqa.dely_JB->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedy_JB, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // if ( eventqa.delx_JB ) {
+  //   eventqa.delx_JB->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedx_JB, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
+  // if ( eventqa.delQ2_JB ) {
+  //   eventqa.delQ2_JB->Draw("colz");
+  //   t.DrawText( missx,missy2, Form("Missed: %ld / %ld",eventqa.missedQ2_JB, qapars.usedevents));
+  //   gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+  // }
 
   // particle QA
   // -----------
   gStyle->SetStatX(0.55); // reposition stat box
+  for ( auto& pidcoll : qabook ){
+    auto& pid = pidcoll.first;
+    auto& coll = pidcoll.second;
 
-  // iterating over the qabook is numerically sorted by pid
-  // We'd rather use the order specified in the pids vector
-  // for ( auto& pidcoll : qabook ){
-  //   auto& pid = pidcoll.first;
-  //   auto& coll = pidcoll.second;
-  
-  for ( auto& pid : qapars.pids ){
-    auto& coll = qabook[pid];
-
-    // option "s" in Profile shows rms    
+    // option "s" in Profile shows rms
+    
     coll.DelP_th->Draw("colz");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
 
     coll.DelP_eta->Draw("colz");
     coll.DelP_eta->ProfileX("_px",1,-1,"s")->Draw("same");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
 
+    gStyle->SetStatX(0.25); // reposition stat box
     coll.DelE_th->Draw("colz");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
     
     coll.DelE_eta->Draw("colz");
     coll.DelE_eta->ProfileX("_px",1,-1,"s")->Draw("same");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
+    gStyle->SetStatX(0.55); // reposition stat box
 
     coll.DelE_E->Draw("colz");
     coll.DelE_E->ProfileX("_px",1,-1,"s")->Draw("same");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
 
     coll.dTh_p->Draw("colz");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
     
     coll.dEta_p->Draw("colz");
     coll.dEta_p->ProfileX("_px",1,-1,"s")->Draw("same");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
 
     coll.dPhi_p->Draw("colz");
     coll.dPhi_p->ProfileX("_px",1,-1,"s")->Draw("same");
-    gPad->SaveAs( pdfname );
+    gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf" );
   }
 
   // return to standard warning level
   gErrorIgnoreLevel = kInfo;
 
   // close the pdf collection
-  gPad->SaveAs( pdfname +"]" );
+  gPad->SaveAs( qapars.outfilebase + qapars.detstring + ".pdf]" );
 }
 // ---------------------------------------------------------------


### PR DESCRIPTION
On request from Jets/HF PWG, added two smearing scripts to evaluate tracking options. These are based on Matrix 0.1, but replace momentum resolution with values from 
https://indico.bnl.gov/event/9984/contributions/43066/attachments/31173/49186/YR_Detector_Matrix_Tracking_only_10282020.xlsx

The smearer scripts are ```SmearTrackingPreview_0_2_B1_5T.cxx``` and ```SmearTrackingPreview_0_2_B1_5T.cxx``` for B=1.5 T and B=3T, respectively, with corresponding ```Build...``` methods. 

Shortcuts for BuildByName are ```TRACKINGPREVIEW_0_2_B1_5T```, ```TRACKING_0_2_B1_5T```, or ```TRACKING02B15``` (and the same scheme for 3T).